### PR TITLE
Add agentic coding guidance and Google Maps Platform skills

### DIFF
--- a/.codex/skills/agentic-repo-stewardship/SKILL.md
+++ b/.codex/skills/agentic-repo-stewardship/SKILL.md
@@ -1,0 +1,31 @@
+# Agentic Repo Stewardship
+
+Use this skill when planning, implementing, reviewing, or handing off code changes in this repository.
+
+## Start-of-task checklist
+
+1. Read the root `AGENTS.md` and any nested instructions in touched paths.
+2. Run `git status --short` and preserve existing user changes.
+3. Identify the smallest safe change that satisfies the request.
+4. List affected runtime surfaces: Flask routes, templates, static assets, Celery jobs, database migrations, provider APIs, deployment config, or docs.
+
+## Implementation guidance
+
+- Prefer explicit, documented configuration over implicit defaults.
+- Keep changes reversible and easy to review.
+- Do not add secrets or real user data to tests, fixtures, docs, screenshots, or logs.
+- For legacy code, match the local style before introducing new patterns.
+- If modernizing, isolate compatibility changes and document migration risks.
+
+## Review checklist
+
+- `git diff --check` has no whitespace errors.
+- New environment variables are documented.
+- Security and privacy impacts are called out.
+- Database and background-job changes include operational notes.
+- User-visible web changes include screenshot evidence when a browser is available.
+- Generated files are intentionally updated and source files are included.
+
+## Handoff format
+
+Provide a concise summary, cite changed files, list checks with pass/warn/fail status, and mention any follow-up risks.

--- a/.codex/skills/google-maps-platform-deployment/SKILL.md
+++ b/.codex/skills/google-maps-platform-deployment/SKILL.md
@@ -1,0 +1,46 @@
+# Google Maps Platform Deployment
+
+Use this skill when preparing Google Maps Platform features for staging, production, Heroku deployment, CI/CD, observability, quotas, billing, or rollback.
+
+Primary references to verify when making substantive changes:
+
+- Google Maps Platform getting started: https://developers.google.com/maps/get-started
+- API security best practices: https://developers.google.com/maps/api-security-best-practices
+- Google Maps Platform web service best practices: https://developers.google.com/maps/documentation/mapmanagement/web-services-best-practices
+- Google Maps Platform domains for firewall allowlists: https://developers.google.com/maps/domains
+
+## Environment and configuration
+
+- Use separate Google Cloud projects or keys for local, staging, and production where possible.
+- Document required environment variables in README or deployment docs.
+- For Heroku, configure secrets with `heroku config:set`; never commit `.env` files containing real values.
+- Fail closed when required provider config is absent, and make the failure actionable.
+
+## Rollout guidance
+
+- Use feature flags or provider-selection settings for new Google Maps Platform paths in this Mapbox-oriented app.
+- Roll out to staging first with production-like referrer restrictions.
+- Verify allowed origins before production cutover.
+- Keep rollback simple: disabling the feature flag or reverting provider config should restore prior behavior.
+
+## Quota, billing, and reliability
+
+- Set Google Cloud budget alerts and monitor quota usage before launch.
+- Apply API restrictions so accidental calls cannot fan out into unrelated billable APIs.
+- Use exponential backoff for transient web-service failures.
+- Do not create synchronized batch requests; add jitter where many jobs may call provider APIs.
+- Define cache policy for data that can be cached under applicable provider terms and product requirements.
+
+## Observability checklist
+
+- Log provider operation names and coarse failure categories, not full URLs with keys or precise private coordinates.
+- Track client-side load failures, server-side timeout rates, quota failures, and billing/authorization errors.
+- Add runbook notes for key rotation, quota exhaustion, and provider outage fallback.
+
+## Release checklist
+
+- Required APIs are enabled in the correct Google Cloud project.
+- Billing is attached and budget alerts are configured.
+- Browser and server keys are separately restricted.
+- Staging and production domains are included in referrer restrictions.
+- Deployment docs list rollback steps.

--- a/.codex/skills/google-maps-platform-security/SKILL.md
+++ b/.codex/skills/google-maps-platform-security/SKILL.md
@@ -1,0 +1,48 @@
+# Google Maps Platform Security
+
+Use this skill for Google Maps Platform API keys, browser loading, server-to-server calls, OAuth-adjacent flows, domain controls, and location-data privacy.
+
+Primary references to verify when making substantive changes:
+
+- Google Maps Platform API security best practices: https://developers.google.com/maps/api-security-best-practices
+- Maps JavaScript API key setup: https://developers.google.com/maps/documentation/javascript/get-api-key
+- Google Maps Platform domains: https://developers.google.com/maps/domains
+- Google Maps Platform security and compliance overview: https://developers.google.com/maps/security/compliance/security-compliance
+
+## Key-management rules
+
+- Never commit Google Maps API keys or service credentials.
+- Use separate keys for browser JavaScript and server-side web service calls.
+- Restrict every key with exactly the appropriate application restriction type and only the APIs that key needs.
+- Browser keys should be restricted by HTTPS referrer for deployed domains and localhost development origins as needed.
+- Server keys should not be exposed to templates or static JavaScript; store them in environment variables or a platform secret manager.
+- Rotate keys when adding restrictions to existing production traffic, when a key may have leaked, or when changing ownership.
+
+## Browser integration rules
+
+- Load Maps JavaScript API over HTTPS.
+- Do not interpolate unrestricted keys into templates.
+- Prefer runtime configuration that fails closed when a required key or map ID is missing.
+- Avoid logging full Maps API URLs that include keys or signed parameters.
+
+## Server integration rules
+
+- Use HTTPS for all Google Maps Platform web service requests.
+- Validate and encode URL parameters.
+- Add retry logic with exponential backoff for transient errors; do not retry permanent authorization, billing, quota, or validation failures blindly.
+- Set explicit timeouts on outbound calls.
+- Avoid proxy endpoints that let clients make arbitrary billable Google Maps requests through your server key.
+
+## Location-data privacy
+
+- Treat athlete GPS tracks as sensitive personal data.
+- Do not expose private routes, home/work locations, or exact historical coordinates unless authorized by the product flow.
+- Prefer aggregation, clipping, simplification, or precision reduction for public maps.
+- Avoid shipping raw private coordinates to third-party APIs unless required, disclosed, and protected by configuration.
+
+## Review checklist
+
+- Keys are split by usage and restricted by referrer/IP/API.
+- No secrets appear in git diff, fixtures, screenshots, logs, or generated assets.
+- CORS/referrer changes are narrow and documented.
+- Quota and billing-abuse paths are rate-limited or otherwise controlled.

--- a/.codex/skills/google-maps-platform-web/SKILL.md
+++ b/.codex/skills/google-maps-platform-web/SKILL.md
@@ -1,0 +1,43 @@
+# Google Maps Platform Web Development
+
+Use this skill when adding or changing Google Maps Platform browser features such as Maps JavaScript API, map IDs, cloud-based styling, markers, data layers, geocoding UI, places, elevation, or route visualization.
+
+Primary references to verify when making substantive changes:
+
+- Maps JavaScript API setup: https://developers.google.com/maps/documentation/javascript/get-api-key
+- Maps JavaScript API release notes and versioning: https://developers.google.com/maps/documentation/javascript/releases
+- Map IDs overview: https://developers.google.com/maps/documentation/javascript/map-ids/mapid-over
+- Cloud-based maps styling: https://developers.google.com/maps/documentation/javascript/cloud-customization
+- Cloud-based styling JSON reference: https://developers.google.com/maps/documentation/javascript/cloud-customization/json-reference
+
+## Repository-specific context
+
+- This app currently uses Mapbox GL JS assets and styles. Google Maps work should be explicitly configured and should not silently replace existing Mapbox behavior.
+- Keep provider-specific code in clearly named files or modules.
+- Document any new template variables, Flask config keys, static assets, or deployment settings.
+
+## Implementation guidelines
+
+- Prefer a map ID for features and styling that require or benefit from Google Cloud-managed configuration.
+- Do not combine inline `styles` with `mapId`; manage map appearance through the map ID when using cloud-based styling.
+- Load only the libraries needed for the feature.
+- Keep initialization idempotent so Turbolinks-like reloads, partial renders, or repeated template includes do not duplicate maps/listeners.
+- Preserve accessibility: map containers need labels or surrounding context, controls must be keyboard reachable, and non-map fallbacks should exist for critical data.
+- Handle API load failures with user-visible fallback messaging rather than blank screens.
+- Avoid sending high-precision private GPS data to browser maps unless the user flow requires it.
+
+## Performance guidelines
+
+- Bound and simplify large GeoJSON/track payloads before rendering.
+- Prefer server-side tiling or vector-tile approaches for large datasets.
+- Debounce viewport-driven provider calls.
+- Cache non-user-specific metadata when allowed.
+- Avoid initializing hidden maps until visible, because hidden containers often produce incorrect sizing and wasted billable work.
+
+## Testing checklist
+
+- Verify missing/invalid key behavior.
+- Verify map ID/style behavior in development and production-like origins.
+- Test large route datasets and empty datasets.
+- Confirm no API key or coordinate payload is logged unexpectedly.
+- For visible UI changes, capture a screenshot when possible.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,70 @@
+# Agentic Coding Guide
+
+This repository is a legacy Flask/PostGIS web application for generating map-based athlete visualizations. Treat changes as production-impacting: the app handles OAuth tokens, location traces, map-rendering credentials, generated images, background jobs, and deployment configuration.
+
+## Repository context
+
+- Runtime: Python/Flask application with Celery workers, Redis, PostgreSQL/PostGIS, SQLAlchemy models, Alembic migrations, Flask-Assets bundles, Jinja templates, and static JavaScript/CSS.
+- Mapping stack: existing production code uses Mapbox GL JS assets and map styles. If adding Google Maps Platform features, keep them isolated behind explicit configuration and avoid mixing providers in one rendering path unless the product requirement says so.
+- Deployment target: Heroku-style Procfile/runtime configuration. Preserve compatibility with environment-variable configuration.
+
+## Required workflow for coding agents
+
+1. Read this file before editing. Also check for more deeply nested `AGENTS.md` files in any directory you touch.
+2. Inspect `git status --short` before making changes. Do not overwrite user work.
+3. Prefer small, reviewable changes with clear migration/deployment notes.
+4. Never commit secrets, access tokens, OAuth credentials, API keys, database URLs, Redis URLs, private certificates, generated customer exports, or real athlete GPS traces.
+5. Keep credentials in environment variables or platform secret managers only. Do not add fallback demo keys.
+6. For web UI changes, verify templates/static assets and take a screenshot when the change is perceptible in a runnable browser environment.
+7. For database changes, include Alembic migrations and describe any PostGIS extension or data backfill requirements.
+8. For background-job changes, consider Celery idempotency, retry safety, Redis broker settings, and partial failure behavior.
+9. For geospatial changes, validate coordinate order, SRID assumptions, bounding boxes, precision, and privacy impact.
+10. Update README or operational docs when setup, deployment, environment variables, or provider requirements change.
+
+## Local skills for this repository
+
+Agents should use the local skills in `.codex/skills/` when relevant:
+
+- `agentic-repo-stewardship`: general repo-safe coding, review, and handoff checklist.
+- `google-maps-platform-web`: Google Maps Platform web implementation guidance.
+- `google-maps-platform-deployment`: deployment, observability, quota, and rollout guidance for Google Maps Platform integrations.
+- `google-maps-platform-security`: API key, OAuth, domain restriction, and location-data privacy guidance.
+
+## Coding conventions
+
+- Keep Python 2 compatibility in existing runtime code unless a task explicitly upgrades the application. The current README and runtime configuration indicate a legacy Python 2/Heroku app.
+- Avoid broad rewrites. Match nearby style when touching legacy files.
+- Do not wrap imports in `try`/`except` blocks.
+- Prefer explicit environment-variable names and document every new required variable.
+- Keep vendor assets clearly separated from application-authored code.
+- Avoid adding new minified/generated assets by hand unless the build process requires it and the source is also committed.
+
+## Security and privacy guardrails
+
+- Treat Strava activity data and GPS tracks as sensitive personal location data.
+- Minimize stored location precision when exact routes are not required.
+- Avoid logging coordinates, OAuth tokens, signed URLs, API keys, session cookies, or request bodies containing personal data.
+- Use HTTPS-only URLs for external APIs and generated asset delivery.
+- Review CORS changes carefully; do not broaden origins without a concrete deployment reason.
+- Make API abuse controls explicit for map tiles, geocoding, places, elevation, and other billable provider calls.
+
+## Validation expectations
+
+Run the most relevant checks available for the files changed. Examples:
+
+- `git diff --check`
+- Python syntax checks for changed Python files, using the interpreter supported by the environment.
+- Targeted unit/integration tests when present.
+- Template/static smoke checks for UI changes.
+- Secret scans with available local tooling, or a focused `rg` review for common credential names.
+
+If the environment cannot run a check because dependencies or services are missing, report that clearly in the final handoff.
+
+## Pull request notes
+
+Summaries should include:
+
+- What changed and why.
+- Security/deployment impacts.
+- Tests and checks run.
+- Any skipped checks or follow-up work.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,11 @@ Obtain an application ID, then set environment variables
 3) Navigate to localhost:33507 to open the ADV homepage
 
 
+
+# Agentic coding setup
+
+This repository includes a root `AGENTS.md` with coding-agent operating instructions and local Codex skills in `.codex/skills/`. Agents should read those files before making changes, especially for Google Maps Platform web development, deployment, and security work.
+
 ## Credits
 
 * [Matthew Petroff](http://mpetroff.net/), (Print Maps)


### PR DESCRIPTION
### Motivation

- Provide explicit agent-facing guidance and guardrails for working safely on this legacy Flask/PostGIS mapping app that handles OAuth tokens, GPS traces, background jobs, and provider credentials. 
- Equip agents with focused, local skills for Google Maps Platform web integration, deployment, and security so new provider work is isolated and follows best practices.

### Description

- Add a root `AGENTS.md` that documents repository context, required agent workflow, coding conventions, security/privacy guardrails, validation expectations, and PR handoff notes.  
- Add `.codex/skills/agentic-repo-stewardship/SKILL.md` with start-of-task, implementation, review, and handoff checklists for safe changes.  
- Add Google Maps Platform skills in `.codex/skills/` for `google-maps-platform-web`, `google-maps-platform-security`, and `google-maps-platform-deployment` that cover key management, browser/server integration, privacy, performance, rollout, and observability guidance.  
- Update `README.md` to reference the agentic coding setup and the presence of `AGENTS.md` and `.codex/skills`.

### Testing

- Performed repository whitespace/diff sanity checks and they passed.  
- Verified the new `AGENTS.md` and `.codex/skills/*/SKILL.md` files are present in the project tree.  
- Ran a secret-pattern scan across `AGENTS.md`, `.codex/skills`, and `README.md` for common API key and credential names and only detected existing README placeholder environment-variable examples, not actual secrets.  
- All automated checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36ab897d548327be5f824f3ad6584d)